### PR TITLE
DOC Assorted fixes and additions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 **sklearn-stub** is a template project for [scikit-learn](http://scikit-learn.org/) 
 compatible extensions.
-It is aimed to aid development of `scikit-learn` comptatible algorithms. It
-comes pre-packaged with unit tests, a documentation website and easy to setup
-continuous integration. Conforming to the template's structure will allow users
-to use your library just like scikit-learn packages. The idea is to let
-programmer focus on writing code while unit tests, documentation and continuous
-integration can be setup with minimal changes.
+
+It aids development of estimators that can be used in scikit-learn pipelines
+and (hyper)parameter search, while facilitating testing (including some API
+compliance), documentation, open source development, packaging, and continuous
+integration.
 
 ## Important Links
 HTML Documentation - http://vighneshbirodkar.github.io/sklearn-stub/docs/
 
 ## Installation and Usage
 The package by itself comes with a single module and an estimator. Before
-installing the module you will need `numpy` and `scipy`.
-To install the module execte.
+installing the module you will need `numpy`, `scipy`.
+To install the module execute:
 ```shell
 $ python setup.py install
 ```
-If the installation is successful you should be able to execute the following in
-Python
+
+If the installation is successful, and `scikit-learn` is correctly installed,
+you should be able to execute the following in Python:
 ```python
 >>> from sklstub.stub import StubEstimator
 >>> estimator = StubEstimator()
@@ -37,26 +37,53 @@ tests under `sklstub/tests` which can be run using `nosetests`.
 
 ## Creating your own library
 ### 1. Forking
-Fork the project from its [Github Source Page](https://github.com/vighneshbirodkar/sklearn-stub). You
-might also want to rename from the project from the settings page.
+Fork the project from its [Github Source Page](https://github.com/vighneshbirodkar/sklearn-stub).
+You should rename the project from the settings page.
 
 ### 2. Modifying the Source
 You are free to modify the source as you want, but at the very least, all your
-estimators pass the `check_estimator` test to be scikit-learn compatible.
+estimators should pass the [`check_estimator`](http://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.check_estimator.html#sklearn.utils.estimator_checks.check_estimator)
+test to be scikit-learn compatible.
+
+This template is particularly useful for publishing open-source versions of
+algorithms that do not meet the criteria for inclusion in the core scikit-learn
+package (see [FAQ](http://scikit-learn.org/stable/faq.html)), such as recent
+and unpopular developments in machine learning.
+However, developing using this template may also be a stepping stone to
+eventual inclusion in the core package.
+
+In any case, developers should endeavor to adhere to scikit-learn's
+[Contributor's Guide](http://scikit-learn.org/stable/developers/) which promotes
+the use of:
+* algorithm-specific unit tests, in addition to `check_estimator`'s common tests
+* [PEP8](https://www.python.org/dev/peps/pep-0008/)-compliant code
+* a clearly documented API using [NumpyDoc](https://github.com/numpy/numpydoc)
+  and [PEP257](https://www.python.org/dev/peps/pep-0257/)-compliant docstrings
+* references to relevant scientific literature in standard citation formats
+* [doctests](https://docs.python.org/3/library/doctest.html) to provide
+  succinct usage examples
+* standalone examples to illustrate the usage, model visualisation, and
+  benefits/benchmarks of particular algorithms
+* efficient code when the need for optimization is supported by benchmarks
 
 ### 3. Modifying the Documentation
-The documentation is located under the `doc/` folder and is built using [sphinx](http://www.sphinx-doc.org/en/stable/).
+
+The documentation is built using [sphinx](http://www.sphinx-doc.org/en/stable/).
+It incorporates narrative documentation from the `doc/` directory, standalone
+examples from the `examples/` directory, and API reference compiled from
+estimator docstrings.
+
 To build the documentation locally, ensure that you have `sphinx`,
-`sphinx-gallery` and `matplotlib` by executing.s
+`sphinx-gallery` and `matplotlib` by executing:
 ```shell
 $ pip install sphinx matplotlib sphinx-gallery
 ```
 The documentation contains a home page (`doc/index.rst`), an API
-documentation page (`api.rst`) and a page documenting the `stub` module 
-(`stub.rst`). Sphinx allows you to automcatically document your modules and
+documentation page (`doc/api.rst`) and a page documenting the `stub` module 
+(`doc/stub.rst`). Sphinx allows you to automatically document your modules and
 classes by using the `autodoc` directive (see `stub.rst`). To change the
 asthetics of the docs and other paramteres, edit the `doc/conf.py` file. For
-more information visit the [Sphinx Documentation](http://www.sphinx-doc.org/en/stable/contents.html)
+more information visit the [Sphinx Documentation](http://www.sphinx-doc.org/en/stable/contents.html).
 
 You can also add code examples in the `examples` folder. All files inside
 the folder of the form `plot_*.py` will be executed and their generated
@@ -64,8 +91,8 @@ plots will be available for viewing in the `/auto_examples` URL.
 
 To build the documentation locally execute
 ```shell
-cd doc
-make html
+$ cd doc
+$ make html
 ```
 
 ### 4. Setting up Travis CI
@@ -75,7 +102,7 @@ you sign up and authourize TravisCI, add your new repository to TravisCI so that
 it can start building it. The `travis.yml` file already contains the
 configuration required for Travis to build the project. Once you add the
 project on TravisCI, all subsequent pushes on the master branch will trigger
-a Travis build. By default, the project is tested on Python 2.7 and Python 3.5
+a Travis build. By default, the project is tested on Python 2.7 and Python 3.5.
 
 ### 5. Setting up Coveralls
 [Coveralls](https://coveralls.io/) reports code coverage statistics of your
@@ -118,4 +145,15 @@ Follow the instructions to add a [Travis Badge](https://docs.travis-ci.com/user/
 [CircleCI Badge](https://circleci.com/docs/status-badges) to your repository's
 `README`.
 
+### 8. Advertising your package
 
+Once your work is mature enough for the general public to use it, you should
+submit a Pull Request to modify scikit-learn's
+[related projects listing](https://github.com/scikit-learn/scikit-learn/edit/master/doc/related_projects.rst).
+Please insert brief description of your project and a link to its code
+repository or PyPI page.
+You may also wish to announce your work on the
+[`scikit-learn-general` mailing list](https://lists.sourceforge.net/lists/listinfo/scikit-learn-general).
+
+
+*Thank you for cleanly contributing to the scikit-learn ecosystem!*


### PR DESCRIPTION
This includes a rewrite of the opening paragraph, a rundown of scikit-learn coding/documentation conventions, a note on advertising mature packages, and various fixes to typos.

What could still be added:
- Notes on packaging and publishing to pypi. Perhaps, given that `setup.py` may reuse some of the strings entered for CircleCI and similar, there's a way to allow the developer to enter key details (project name, author, email, repo URL, version) only once.
- Do we want to specify a naming convention for extension packages? Should they generally be prefixed with `sklearn-`, or on the contrary do we want to reserve that for core-owned projects? (Ping @GaelVaroquaux; though I guess reserving it is unrealistic.)
- Something on ideal Python, NumPy, SciPy version compatibility, or a reference to scikit-learn's policy on this

Also, should the README be in RST rather than markdown, so that users who don't realise they have a choice aren't forced to learn a further technology?
