### PR TITLE
Bump numpy and scipy versions on py3 to handle libgfortran linking bug (was Temporarily disable MKL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="2.7"
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0" CYTHON_VERSION="0.21"
     - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
-      NUMPY_VERSION="1.10.1" SCIPY_VERSION="0.16.0" CYTHON_VERSION="0.23.4"
+      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0" CYTHON_VERSION="0.23.4"
 
 install: source ci_scripts/install.sh
 script: bash ci_scripts/test.sh

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -25,8 +25,8 @@ popd
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
-   numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION cython=$CYTHON_VERSION
-   matplotlib
+      numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION cython=$CYTHON_VERSION
+
 source activate testenv
 
 


### PR DESCRIPTION
Fix copied from
https://github.com/scikit-learn/scikit-learn/pull/6508
