### PR TITLE
Fix AssertionError when using TemplateTransformer

### DIFF
--- a/skltemplate/template.py
+++ b/skltemplate/template.py
@@ -185,6 +185,6 @@ class TemplateTransformer(BaseEstimator, TransformerMixin):
         # Check that the input is of the same shape as the one passed
         # during fit.
         if X.shape != self.input_shape_:
-            raise ValueError('Shape of input is different from what was seen'
-                             'in `fit`')
+            raise ValueError('Reshape your data. Shape of input is different'
+                             ' from what was seen in `fit`')
         return np.sqrt(X)


### PR DESCRIPTION
As-is, TemplateTransformer fails with the following code:

    from sklearn.utils.estimator_checks import check_estimator
    tpl = TemplateTransformer()
    check_estimator(tpl)

> AssertionError: Error message does not include the expected string: 'Reshape your data'. Observed error message: 'Shape of input is different from what was seen in `fit`'

Changing the message within ValueError to include the expected string fixes this issue.