### PR TITLE
Added .editorconfig according to PEP 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.py]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+end_of_line = lf


### PR DESCRIPTION
The stuff sets prefs of a text editor (lot of different editors support this feature) to use the conventions used in PEP8 only for files in the folder where the file lies. It is useful for the ones having editor settings contradicting pep8.