### PR TITLE
Reorder parent classes.

### DIFF
--- a/skltemplate/_template.py
+++ b/skltemplate/_template.py
@@ -61,7 +61,7 @@ class TemplateEstimator(BaseEstimator):
         return np.ones(X.shape[0], dtype=np.int64)
 
 
-class TemplateClassifier(BaseEstimator, ClassifierMixin):
+class TemplateClassifier(ClassifierMixin, BaseEstimator):
     """ An example classifier which implements a 1-NN algorithm.
 
     For more information regarding how to build your own classifier, read more
@@ -133,7 +133,7 @@ class TemplateClassifier(BaseEstimator, ClassifierMixin):
         return self.y_[closest]
 
 
-class TemplateTransformer(BaseEstimator, TransformerMixin):
+class TemplateTransformer(TransformerMixin, BaseEstimator):
     """ An example transformer that returns the element-wise square root.
 
     For more information regarding how to build your own transformer, read more


### PR DESCRIPTION
I believe subclassing from `(mixin, base)` is the correct and idiomatic way of multiple inheritance here.*
My understanding is that mixins should come **before** the base class in the mro.

ps. `sklearn` also uses this order everywhere in the code -- except for the [docs about the project template](https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator).

*= even though it has no practical effect here.