### PR TITLE
DOC update class template for sphinx documentation

### DIFF
--- a/doc/_templates/class.rst
+++ b/doc/_templates/class.rst
@@ -4,6 +4,7 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   :members:
 
    {% block methods %}
    .. automethod:: __init__


### PR DESCRIPTION
Hi all, currently, the html pages do not show the documentation of methods other than `__init__`. In particular, `fit` and `predict` methods do not appear on the generated documentation. I think the problem comes from the `doc/_templates/class.rst` file.

So I suggest to add one line to this file to solve the problem. Hereafter are screenshots "before/after" the change :

**BEFORE** 

<img width="400" alt="before" src="https://user-images.githubusercontent.com/57913701/120652685-4c4e7400-c480-11eb-8856-42279ef01016.png">

**AFTER**

<img width="400" alt="after" src="https://user-images.githubusercontent.com/57913701/120652693-4eb0ce00-c480-11eb-8f29-90a0db109100.png">
