### PR TITLE
Fix appveyor python version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ install:
   - "conda install --yes -c conda-forge pip numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION%"
   - pip install codecov nose pytest pytest-cov
   - pip install .
-  - python --version
 
 test_script:
   - mkdir for_test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - "conda install --yes -c conda-forge pip numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION%"
   - pip install codecov nose pytest pytest-cov
   - pip install .
+  - python --version
 
 test_script:
   - mkdir for_test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 build: false
 
 environment:
+  MINICONDA: "C:\\Miniconda3-x64"
   matrix:
-    MINICONDA: "C:\\Miniconda3-x64"
     - PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
       NUMPY_VERSION: "1.13.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ build: false
 
 environment:
   matrix:
-  MINICONDA: "C:\\Miniconda3-x64"
+    MINICONDA: "C:\\Miniconda3-x64"
     - PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
       NUMPY_VERSION: "1.13.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   # https://github.com/conda/conda/issues/1753
   - cmd: call %MINICONDA%\Scripts\activate.bat
   # install the dependencies
-  - conda create -n test-env --yes -c conda-forge python==%PYTHON_VERSION% numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION% codecov nose pytest pytest-cov
+  - conda create -n test-env --yes -c conda-forge python=%PYTHON_VERSION% numpy=%NUMPY_VERSION% scipy=%SCIPY_VERSION% scikit-learn=%SKLEARN_VERSION% codecov nose pytest pytest-cov
   - conda activate test-env
   - pip install .
   - python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,15 @@ build: false
 environment:
   MINICONDA: "C:\\Miniconda3-x64"
   matrix:
-    - PYTHON_VERSION: "3.5.x"
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
       NUMPY_VERSION: "1.13.1"
       SCIPY_VERSION: "0.19.1"
       SKLEARN_VERSION: "0.19.1"
 
-    - PYTHON_VERSION: "3.6.x"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "*"
       SCIPY_VERSION: "*"
@@ -21,7 +23,7 @@ install:
   # https://github.com/conda/conda/issues/1753
   - cmd: call %MINICONDA%\Scripts\activate.bat
   # install the dependencies
-  - conda create -n test-env --yes -c conda-forge python=%PYTHON_VERSION% numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION% codecov nose pytest pytest-cov
+  - conda create -n test-env --yes -c conda-forge numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION% codecov nose pytest pytest-cov
   - conda activate test-env
   - pip install .
   - python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,16 +3,12 @@ build: false
 environment:
   MINICONDA: "C:\\Miniconda3-x64"
   matrix:
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
+    - PYTHON_VERSION: "3.5"
       NUMPY_VERSION: "1.13.1"
       SCIPY_VERSION: "0.19.1"
       SKLEARN_VERSION: "0.19.1"
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
+    - PYTHON_VERSION: "3.6"
       NUMPY_VERSION: "*"
       SCIPY_VERSION: "*"
       SKLEARN_VERSION: "*"
@@ -23,7 +19,7 @@ install:
   # https://github.com/conda/conda/issues/1753
   - cmd: call %MINICONDA%\Scripts\activate.bat
   # install the dependencies
-  - conda create -n test-env --yes -c conda-forge numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION% codecov nose pytest pytest-cov
+  - conda create -n test-env --yes -c conda-forge python==%PYTHON_VERSION% numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION% codecov nose pytest pytest-cov
   - conda activate test-env
   - pip install .
   - python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,14 @@ build: false
 
 environment:
   matrix:
-    - PYTHON: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.5.x"
+  MINICONDA: "C:\\Miniconda3-x64"
+    - PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
       NUMPY_VERSION: "1.13.1"
       SCIPY_VERSION: "0.19.1"
       SKLEARN_VERSION: "0.19.1"
 
-    - PYTHON: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.6.x"
+    - PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "*"
       SCIPY_VERSION: "*"
@@ -20,10 +19,10 @@ install:
   # Prepend miniconda installed Python to the PATH of this build
   # Add Library/bin directory to fix issue
   # https://github.com/conda/conda/issues/1753
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
+  - cmd: call %MINICONDA%\Scripts\activate.bat
   # install the dependencies
-  - "conda install --yes -c conda-forge pip numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION%"
-  - pip install codecov nose pytest pytest-cov
+  - conda create -n test-env --yes -c conda-forge python=%PYTHON_VERSION% numpy==%NUMPY_VERSION% scipy==%SCIPY_VERSION% scikit-learn==%SKLEARN_VERSION% codecov nose pytest pytest-cov
+  - conda activate test-env
   - pip install .
   - python --version
 


### PR DESCRIPTION
In the appveyor CI, I noticed a mismatch between the _intended_ python version and the _actual_ python version used. Whatever is the environment (as defined by the matrix), python version is always 3.7.6, instead of the _intended_ 3.5 and 3.6 ones. It seems that the python version used in the build is in fact related to the `MINICONDA` version, and not the `PYTHON_VERSION`.

Since conda offers the opportunity to install on-the-fly a given python version, I propose to : 

* remove the `PYTHON_ARCH` options, which were apparently not used anyway
* use `conda create python=%PYTHON_VERSION%` instead of `conda install`
* activate this environment with `conda activate`. Note that this step needs to declare where the conda binary is, which can be made with a simple preamble `cmd: ` statement.

Hereafter are screenshots of "before/after" on the _intended_ python 3.6 build : 

**BEFORE**

<img width="794" alt="before" src="https://user-images.githubusercontent.com/57913701/120664912-9d179a00-c48b-11eb-95fa-436ab6de4a1b.png">

**AFTER**

<img width="908" alt="after" src="https://user-images.githubusercontent.com/57913701/120664936-a1dc4e00-c48b-11eb-8257-9900741d9201.png">
