### PR TITLE
fix unit tests for python 3.6 and sklearn latest

### DIFF
--- a/skltemplate/_template.py
+++ b/skltemplate/_template.py
@@ -27,7 +27,7 @@ class TemplateEstimator(BaseEstimator):
     >>> y = np.zeros((100, ))
     >>> estimator = TemplateEstimator()
     >>> estimator.fit(X, y)
-    TemplateEstimator(demo_param='demo_param')
+    TemplateEstimator()
     """
     def __init__(self, demo_param='demo_param'):
         self.demo_param = demo_param

--- a/skltemplate/tests/test_common.py
+++ b/skltemplate/tests/test_common.py
@@ -8,7 +8,8 @@ from skltemplate import TemplateTransformer
 
 
 @pytest.mark.parametrize(
-    "estimator", [TemplateEstimator(), TemplateTransformer(), TemplateClassifier()]
+    "estimator",
+    [TemplateEstimator(), TemplateTransformer(), TemplateClassifier()]
 )
 def test_all_estimators(estimator):
     return check_estimator(estimator)

--- a/skltemplate/tests/test_common.py
+++ b/skltemplate/tests/test_common.py
@@ -8,7 +8,7 @@ from skltemplate import TemplateTransformer
 
 
 @pytest.mark.parametrize(
-    "Estimator", [TemplateEstimator, TemplateTransformer, TemplateClassifier]
+    "estimator", [TemplateEstimator(), TemplateTransformer(), TemplateClassifier()]
 )
-def test_all_estimators(Estimator):
-    return check_estimator(Estimator)
+def test_all_estimators(estimator):
+    return check_estimator(estimator)

--- a/skltemplate/tests/test_template.py
+++ b/skltemplate/tests/test_template.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from sklearn.datasets import load_iris  
+from sklearn.datasets import load_iris
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_allclose
 

--- a/skltemplate/tests/test_template.py
+++ b/skltemplate/tests/test_template.py
@@ -1,9 +1,10 @@
 import pytest
 import numpy as np
 
+from sklearn.datasets import load_iris
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_allclose
-from sklearn.datasets import load_iris
+
 
 from skltemplate import TemplateEstimator
 from skltemplate import TemplateTransformer

--- a/skltemplate/tests/test_template.py
+++ b/skltemplate/tests/test_template.py
@@ -1,9 +1,9 @@
 import pytest
 import numpy as np
 
+from sklearn.utils._testing import assert_array_equal
+from sklearn.utils._testing import assert_allclose
 from sklearn.datasets import load_iris
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_allclose
 
 from skltemplate import TemplateEstimator
 from skltemplate import TemplateTransformer

--- a/skltemplate/tests/test_template.py
+++ b/skltemplate/tests/test_template.py
@@ -1,8 +1,8 @@
 import pytest
 import numpy as np
 
-from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_allclose
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose
 from sklearn.datasets import load_iris
 
 from skltemplate import TemplateEstimator

--- a/skltemplate/tests/test_template.py
+++ b/skltemplate/tests/test_template.py
@@ -1,10 +1,9 @@
 import pytest
 import numpy as np
 
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris  
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_allclose
-
 
 from skltemplate import TemplateEstimator
 from skltemplate import TemplateTransformer


### PR DESCRIPTION
Hi all, I have noticed that unit tests do not pass, so I suggest minor changes to fix this.

Actually, there is a mismatch between sklearn 0.19.1 and sklearn 0.24.2, so I cannot make unit tests pass for all environments tested in appveyor and travis with the same simple code. Since 0.19.1 is quite old by now, I suggest to test only for latest versions of sklearn.

The code is thus adapted to the latest sklearn version, so as to make unit tests pass with the following command 

```
pytest -v --cov=skltemplate --pyargs skltemplate